### PR TITLE
INFRA-861: Only open tempfiles on first sort, optionally close

### DIFF
--- a/lib/offline_sort/chunk/input_output/base.rb
+++ b/lib/offline_sort/chunk/input_output/base.rb
@@ -32,6 +32,10 @@ module OfflineSort
           io.rewind
         end
 
+        def open
+          io.open
+        end
+
         def close
           io.close
         end

--- a/lib/offline_sort/merger.rb
+++ b/lib/offline_sort/merger.rb
@@ -1,0 +1,55 @@
+require 'forwardable'
+
+module OfflineSort
+  class Merger
+    extend Forwardable
+    include Enumerable
+
+    attr_reader :sorted_chunks, :sort_by
+
+    def initialize(sorted_chunks, sort_by)
+      @sorted_chunks = sorted_chunks
+      @sort_by = sort_by
+    end
+
+    def_delegators :enumerator, :each
+
+    private
+
+    def enumerator
+      pq = []
+      chunk_enumerators =
+        sorted_chunks.each(&:open).each(&:rewind).map(&:each)
+
+      chunk_enumerators.each_with_index do |chunk, index|
+        entry = chunk.next
+        pq.push(ChunkEntry.new(index, entry))
+      end
+
+      entry_sort_by = Proc.new { |entry| sort_by.call(entry.data) }
+      pq = FixedSizeMinHeap.new(pq, &entry_sort_by)
+
+      Enumerator.new do |yielder|
+        while item = pq.pop
+          yielder.yield(item.data)
+
+          begin
+            entry = chunk_enumerators[item.chunk_number].next
+            pq.push(ChunkEntry.new(item.chunk_number, entry))
+          rescue StopIteration
+            sorted_chunks[item.chunk_number].close
+          end
+        end
+      end
+    end
+
+    class ChunkEntry
+      attr_reader :chunk_number, :data
+
+      def initialize(chunk_number, data)
+        @chunk_number = chunk_number
+        @data = data
+      end
+    end
+  end
+end

--- a/spec/offline_sort/offline_sort_spec.rb
+++ b/spec/offline_sort/offline_sort_spec.rb
@@ -1,113 +1,135 @@
 require 'spec_helper'
 
 describe OfflineSort::Sorter do
+  describe "#sort" do
+    subject { offline_sorter_instance.sort.to_a }
 
-  shared_examples "a correct offline sort" do
-    let(:count) { 10000 }
+    let(:offline_sorter_instance) do
+      described_class.new(enumerable, chunk_size: entries_per_chunk, &sort)
+    end
+
     let(:entries_per_chunk) { 900 }
-    let(:enumerable) {}
-    let(:sort) {}
-    let(:unsorted) { enumerable.dup }
-
-    subject do
-      OfflineSort.sort(enumerable, chunk_size: entries_per_chunk, &sort)
-    end
-
-    it "writes out to disk" do
-      expect(Tempfile).to receive(:open).at_least(:once).and_call_original
-      subject
-    end
-
-    shared_examples "produces a sorted result" do
-      it "produces the same sorted result as an in-memory sort" do
-        sorted = subject.to_a
-
-        expect(unsorted).to match_array(enumerable)
-        expect do
-          last = nil
-          entry_count = 0
-          sorted.each do |entry|
-            if last.nil?
-              last = entry
-              entry_count += 1
-              next
-            end
-
-            unless (sort.call(last) <=> sort.call(entry)) == -1
-              raise "Out of order at line #{entry_count}"
-            end
-
-            last = entry
-            entry_count += 1
-          end
-        end.not_to raise_error
-        expect(sorted).to match_array(enumerable.sort_by(&sort))
+    let(:count) { 10000 }
+    let(:enumerable) { arrays }
+    let(:sort) { array_sort }
+    let(:array_sort) { Proc.new { |arr| arr[2] } }
+    let(:arrays) do
+      count.times.map do |index|
+        [SecureRandom.hex, index, SecureRandom.hex]
       end
     end
 
-    context "when the number of entries is smaller than the chunk size" do
-      let(:count) { entries_per_chunk - 1 }
+    shared_examples "a correct offline sort" do
+      let(:unsorted) { enumerable.dup }
 
-      it "does not write out to disk" do
-        expect(Tempfile).not_to receive(:open)
+      it "writes out to disk" do
+        expect(Tempfile).to receive(:open).at_least(:once).and_call_original
         subject
+      end
+
+      shared_examples "produces a sorted result" do
+        it "produces the same sorted result as an in-memory sort" do
+          expect(unsorted.sort_by(&sort)).to eq(subject)
+        end
+
+        context "closing tempfiles" do
+          it "closes all tempfiles" do
+            close_count = 0
+            allow_any_instance_of(Tempfile).
+              to receive(:close) { close_count += 1 }
+
+            expected_number_of_tempfiles =
+              (count.to_f / entries_per_chunk).ceil
+
+            # The case where we don't write to disk because there's only
+            # one chunk
+            if expected_number_of_tempfiles == 1
+              expected_number_of_tempfiles = 0
+            end
+
+            subject
+            expect(close_count).to eq(expected_number_of_tempfiles)
+          end
+        end
+
+        context "when sorted twice" do
+          subject { offline_sorter_instance.sort }
+
+          it "produces the same result both times" do
+            expect(subject.to_a).to eq(subject.to_a)
+          end
+
+          it "only calls sort the first time" do
+            offline_sort = offline_sorter_instance.sort
+            in_memory_sort = unsorted.sort_by(&sort)
+            # By clearing the enumerable, and then asserting that the offline
+            # sort has the same result as the in memory sort, we are asserting
+            # that the offline sort must have cached a value derived from the
+            # enumerable, and is not caculating anything based on the to_a
+            # call.
+            enumerable.clear
+            expect(offline_sort.to_a).to eq(in_memory_sort)
+            # This assertion is validating that we did, in fact, clear the
+            # enumerable such that if we now try to offline sort, we have no
+            # elements left in the enumerable.
+            expect(offline_sorter_instance.sort.to_a).to eq([])
+          end
+        end
+      end
+
+      context "when the number of entries is smaller than the chunk size" do
+        let(:count) { entries_per_chunk - 1 }
+
+        it "does not write out to disk" do
+          expect(Tempfile).not_to receive(:open)
+          subject
+        end
+
+        it_behaves_like "produces a sorted result"
       end
 
       it_behaves_like "produces a sorted result"
     end
-  end
 
-  let(:arrays) do
-    count.times.map do |index|
-      [SecureRandom.hex, index, SecureRandom.hex]
-    end
-  end
-
-  let(:array_sort_index) { 2 }
-  let(:array_sort) { Proc.new { |arr| arr[array_sort_index] } }
-
-  let(:hashes) do
-    count.times.map do |index|
-      { 'a' => SecureRandom.hex, 'b' => index, 'c' => SecureRandom.hex }
-    end
-  end
-
-  let(:hash_sort_key) { 'c' }
-  let(:hash_sort) { Proc.new { |hash| hash[hash_sort_key] } }
-
-
-  context "with arrays" do
-    it_behaves_like "a correct offline sort" do
-      let(:enumerable) { arrays }
-      let(:sort) { array_sort }
-    end
-
-    context "with multiple sort keys" do
-      it_behaves_like "a correct offline sort" do
-        let(:enumerable) do
-          count.times.map do |index|
-            [index.round(-1), index, SecureRandom.hex]
-          end.shuffle
-        end
-        let(:sort) { Proc.new { |arr| [arr[0], arr[1]] } }
+    let(:hashes) do
+      count.times.map do |index|
+        { 'a' => SecureRandom.hex, 'b' => index, 'c' => SecureRandom.hex }
       end
     end
-  end
 
-  context "hashes" do
-    it_behaves_like "a correct offline sort" do
-      let(:enumerable) { hashes }
-      let(:sort) { hash_sort }
+    let(:hash_sort_key) { 'c' }
+    let(:hash_sort) { Proc.new { |hash| hash[hash_sort_key] } }
+
+    context "with arrays" do
+      it_behaves_like "a correct offline sort"
+
+      context "with multiple sort keys" do
+        it_behaves_like "a correct offline sort" do
+          let(:enumerable) do
+            count.times.map do |index|
+              [index.round(-1), index, SecureRandom.hex]
+            end.shuffle
+          end
+          let(:sort) { Proc.new { |arr| [arr[0], arr[1]] } }
+        end
+      end
     end
 
-    context "with multiple sort keys" do
+    context "hashes" do
       it_behaves_like "a correct offline sort" do
-        let(:enumerable) do
-          count.times.map do |index|
-            { 'a' => index.round(-1), 'b' => index, 'c' => SecureRandom.hex }
-          end.shuffle
+        let(:enumerable) { hashes }
+        let(:sort) { hash_sort }
+      end
+
+      context "with multiple sort keys" do
+        it_behaves_like "a correct offline sort" do
+          let(:enumerable) do
+            count.times.map do |index|
+              { 'a' => index.round(-1), 'b' => index, 'c' => SecureRandom.hex }
+            end.shuffle
+          end
+          let(:sort) { Proc.new { |hash| [hash['a'], hash['c']] } }
         end
-        let(:sort) { Proc.new { |hash| [hash['a'], hash['c']] } }
       end
     end
   end


### PR DESCRIPTION
This PR changes the OfflineSort::Sort#sort method to only open and write to tempfiles on the first call, and on subsequent calls not write to these tempfiles again. This enables us to call it multiple times with fixed memory, without duplicating the work of writing to tempfiles.

Testing path:
- [X] Confirmed by pushing NDS' develop explicitly linking this branch in the Gemfile that parsing events files remain the same with this change.