### PR TITLE
Delegate next

### DIFF
--- a/lib/offline_sort/merger.rb
+++ b/lib/offline_sort/merger.rb
@@ -12,7 +12,7 @@ module OfflineSort
       @sort_by = sort_by
     end
 
-    def_delegators :enumerator, :each
+    def_delegators :enumerator, :each, :next
 
     private
 


### PR DESCRIPTION
This PR delegates `.next` to the enumerator on a Merger instead of the `Merger` object itself.