### PR TITLE
Expose enumerator, don't delegate next

### DIFF
--- a/lib/offline_sort/merger.rb
+++ b/lib/offline_sort/merger.rb
@@ -12,9 +12,7 @@ module OfflineSort
       @sort_by = sort_by
     end
 
-    def_delegators :enumerator, :each, :next
-
-    private
+    def_delegators :enumerator, :each
 
     def enumerator
       pq = []
@@ -42,6 +40,8 @@ module OfflineSort
         end
       end
     end
+
+    private
 
     class ChunkEntry
       attr_reader :chunk_number, :data


### PR DESCRIPTION
This PR no longer delegates next to the enumerator. Instead, it exposes the enumerator, and we will change our nds code to use this enumerator itself.